### PR TITLE
Windows misleads about virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ In the latter case, users are required to install the driver manually.
 
 
 Prerequisite:
-1. CPU has virtualization extension and BIOS has NOT disabled the extension.
+1. CPU has virtualization extension and BIOS has NOT disabled the extension. Be
+   sure to check the BIOS because Windows can report it as enabled even when it
+   is disabled.
 2. Hyper-V must be disabled. Refer to [this
    page](https://github.com/google/android-emulator-hypervisor-driver-for-amd-processors/wiki/Is-Hyper-V-really-disabled%3F)
    for more information.


### PR DESCRIPTION
I spent a lot of time wondering why I could not install the
virtualization support. The Windows Task Manager said that
virtualization was enabled. I opened the BIOS and it turned out it was
not enabled. I could finally install the virtualization support after
enabling it in the BIOS.

I have added a note in the README.md that Windows can incorrectly report
the virtualization status.